### PR TITLE
Set range for eslint-plugin-node to >=2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/davidtheclark/eslint-config-davidtheclark-node#readme",
   "peerDependencies": {
-    "eslint-plugin-node": "^2.0.0 || ^3.0.0"
+    "eslint-plugin-node": ">=2.0.0"
   }
 }


### PR DESCRIPTION
This allows to use `eslint-plugin-node@5` which I want to upgrade to in `cosmiconfig`.